### PR TITLE
feat: add support for custom hostnames route intersection in worker

### DIFF
--- a/packages/edge-gateway-link/wrangler.toml
+++ b/packages/edge-gateway-link/wrangler.toml
@@ -24,7 +24,8 @@ routes = [
   { pattern = "*.ipfs.w3s.link", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "w3s.link/ipns/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*.ipns.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
-  { pattern = "*.ipns.w3s.link", zone_id = "ae60d8f737317467ec666dc3851a6277" }
+  { pattern = "*.ipns.w3s.link", zone_id = "ae60d8f737317467ec666dc3851a6277" },
+  { pattern = "*/*", zone_id = "ae60d8f737317467ec666dc3851a6277" }
 ]
 
 [env.production.vars]


### PR DESCRIPTION
This PR allows us to support custom hostnames routes and have them being handled by worker. Per https://developers.cloudflare.com/cloudflare-for-saas/workers-for-platforms/worker-as-origin/