### PR TITLE
fix: redirect to product page

### DIFF
--- a/packages/edge-gateway-link/src/gateway.js
+++ b/packages/edge-gateway-link/src/gateway.js
@@ -1,5 +1,7 @@
 /* eslint-env serviceworker, browser */
 
+const PRODUCT_URL = 'https://web3.storage/products/w3link/'
+
 /**
  * Handle gateway request
  *
@@ -7,6 +9,14 @@
  * @param {import('./env').Env} env
  */
 export async function gatewayGet (request, env) {
+  // Redirect to product page
+  if (!request.url.includes('ipfs') && !request.url.includes('ipns')) {
+    return Response.redirect(
+      PRODUCT_URL,
+      302
+    )
+  }
+
   // Redirect if ipns
   if (request.url.includes(env.IPNS_GATEWAY_HOSTNAME)) {
     return Response.redirect(


### PR DESCRIPTION
With Custom hostnames, CF page redirect rules do not work anymore as this is routed into the worker. This PR adds the redirect to product page in the worker then