### PR TITLE
fix: badbits url

### DIFF
--- a/packages/edge-gateway-link/README.md
+++ b/packages/edge-gateway-link/README.md
@@ -62,9 +62,9 @@ w3link is currently rate limited at 200 requests per minute to a given IP Addres
 
 ## Deny List
 
-We rely on [badbits](https://github.com/protocol/badbits.dwebops.pub) denylist together wtth our own denylist to prevent serving malicious content to the nftstorage.link users.
+We rely on [badbits](https://badbits.dwebops.pub/) denylist together wtth our own denylist to prevent serving malicious content to the nftstorage.link users.
 
-When new malicious content is discovered, it should be reported to [badbits](https://github.com/protocol/badbits.dwebops.pub) denylist given it is shared among multiple gateways.
+When new malicious content is discovered, it should be reported to [badbits](https://badbits.dwebops.pub/) denylist given it is shared among multiple gateways.
 
 ## Contributing
 


### PR DESCRIPTION
fix badbits url 🐛

- [https://github.com/protocol/badbits.dwebops.pub](https://github.com/protocol/badbits.dwebops.pub) should be a a private GitHub repository.
- [https://badbits.dwebops.pub/](https://badbits.dwebops.pub/) is a public website.