### PR TITLE
Fix: Typo on Line 41 within edge-gateway-link.md

### DIFF
--- a/packages/edge-gateway-link/README.md
+++ b/packages/edge-gateway-link/README.md
@@ -38,7 +38,7 @@ Zooming in on the actual edge gateway:
 Notes:
 
 - Cloudflare Cache is [limited](https://developers.cloudflare.com/workers/platform/limits/#cache-api-limits) to 512 MB size objects.
-- SUperHot perma-cache is shared with nftstorage.link
+- SuperHot perma-cache is shared with nftstorage.link
 
 ## Usage
 


### PR DESCRIPTION
Super tiny typo fix. On line 41, I changed "SUperHot" to "SuperHot". 

-Now the case sensitivity matches line 26 "SuperHot".  On another note, this repo is so helpful! Thank you so much! I hope I am not wasting anyones time by submitting this PR!