### PR TITLE
feat: apply csp headers with goodbits

### DIFF
--- a/packages/edge-gateway-link/package.json
+++ b/packages/edge-gateway-link/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "itty-router": "^2.4.5",
     "multiformats": "^9.6.4",
+    "p-retry": "^5.1.2",
     "toucan-js": "^2.5.0"
   },
   "devDependencies": {

--- a/packages/edge-gateway-link/src/bindings.d.ts
+++ b/packages/edge-gateway-link/src/bindings.d.ts
@@ -10,7 +10,8 @@ export interface EnvInput {
   LOKI_URL?: string
   LOKI_TOKEN?: string
   EDGE_GATEWAY: Fetcher
-  GATEWAY_HOSTNAME: string,
+  GATEWAY_HOSTNAME: string
+  GOODBITSLIST: KVNamespace
 }
 
 export interface EnvTransformed {

--- a/packages/edge-gateway-link/src/gateway.js
+++ b/packages/edge-gateway-link/src/gateway.js
@@ -1,6 +1,12 @@
 /* eslint-env serviceworker, browser */
 
+import { CID } from 'multiformats/cid'
+import pRetry from 'p-retry'
+
+import { InvalidUrlError } from './errors.js'
+
 const PRODUCT_URL = 'https://web3.storage/products/w3link/'
+const GOODBITS_BYPASS_TAG = 'https://w3s.link/tags/bypass-default-csp'
 
 /**
  * Handle gateway request
@@ -25,7 +31,7 @@ export async function gatewayGet (request, env) {
     )
   }
 
-  return await env.EDGE_GATEWAY.fetch(request.url, {
+  const response = await env.EDGE_GATEWAY.fetch(request.url, {
     headers: request.headers,
     cf: {
       ...request.cf || {},
@@ -33,4 +39,80 @@ export async function gatewayGet (request, env) {
       onlyIfCachedGateways: JSON.stringify(['https://nftstorage.link'])
     }
   })
+
+  // Validation layer - CSP bypass
+  const resourceCid = decodeURIComponent(
+    response.headers.get('etag') || getCidFromSubdomainUrl(new URL(request.url))
+  )
+  const goodbitsTags = await getTagsFromGoodbitsList(
+    env.GOODBITSLIST,
+    resourceCid
+  )
+  if (goodbitsTags.includes(GOODBITS_BYPASS_TAG)) {
+    return response
+  }
+
+  return getTransformedResponseWithCspHeaders(response)
+}
+
+/**
+ * Transforms response with custom headers.
+ * Content-Security-Policy header specified to only allow requests within same origin.
+ *
+ * @param {Response} response
+ */
+function getTransformedResponseWithCspHeaders (response) {
+  const clonedResponse = new Response(response.body, response)
+
+  clonedResponse.headers.set(
+    'content-security-policy',
+    "default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://*.githubusercontent.com; form-action 'self' ; navigate-to 'self'; connect-src 'self' blob: data:"
+  )
+
+  return clonedResponse
+}
+
+/**
+ * Get a given entry from the goodbits list if CID exists, and return tags
+ *
+ * @param {KVNamespace} datastore
+ * @param {string} cid
+ */
+async function getTagsFromGoodbitsList (datastore, cid) {
+  if (!datastore || !cid) {
+    return []
+  }
+
+  const goodbitsEntry = await pRetry(() => datastore.get(cid), { retries: 5 })
+
+  if (goodbitsEntry) {
+    const { tags } = JSON.parse(goodbitsEntry)
+    return Array.isArray(tags) ? tags : []
+  }
+
+  return []
+}
+
+/**
+ * Parse subdomain URL and return cid.
+ *
+ * @param {URL} url
+ */
+export function getCidFromSubdomainUrl (url) {
+  // Replace "ipfs-staging" by "ipfs" if needed
+  const host = url.hostname.replace('ipfs-staging', 'ipfs')
+  const splitHost = host.split('.ipfs.')
+
+  if (!splitHost.length) {
+    throw new InvalidUrlError(url.hostname)
+  }
+
+  let cid
+  try {
+    cid = CID.parse(splitHost[0])
+  } catch (/** @type {any} */ err) {
+    throw new InvalidUrlError(`invalid CID: ${splitHost[0]}: ${err.message}`)
+  }
+
+  return cid.toV1().toString()
 }

--- a/packages/edge-gateway-link/test/gateway.spec.js
+++ b/packages/edge-gateway-link/test/gateway.spec.js
@@ -3,7 +3,7 @@ import { test, getMiniflare } from './utils/setup.js'
 test.beforeEach((t) => {
   // Create a new Miniflare environment for each test
   t.context = {
-    mf: getMiniflare(),
+    mf: getMiniflare()
   }
 })
 
@@ -15,4 +15,54 @@ test('Gets content from binding', async (t) => {
   )
   await response.waitUntil()
   t.is(await response.text(), 'Hello w3s.link! 😎')
+
+  // CSP
+  const csp = response.headers.get('content-security-policy') || ''
+  t.true(csp.includes("default-src 'self' 'unsafe-inline' 'unsafe-eval'"))
+  t.true(csp.includes('blob: data'))
+  t.true(csp.includes("form-action 'self' ; navigate-to 'self';"))
+})
+
+test('Gets content with no csp header when goodbits csp bypass tag exists', async (t) => {
+  const { mf } = t.context
+  const cid = 'bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupor'
+
+  // add the CID to the goodbits list
+  const goodbitsListKv = await mf.getKVNamespace('GOODBITSLIST')
+  await goodbitsListKv.put(
+    cid,
+    JSON.stringify({
+      tags: ['https://w3s.link/tags/bypass-default-csp']
+    })
+  )
+
+  const response = await mf.dispatchFetch(`https://${cid}.ipfs.localhost:8787`)
+  await response.waitUntil()
+  t.is(await response.text(), 'Hello w3s.link! 😎')
+
+  // CSP does not exist
+  const csp = response.headers.get('content-security-policy')
+  t.falsy(csp)
+})
+
+test('Gets content with csp header when goodbits csp bypass tag does not exist', async (t) => {
+  const { mf } = t.context
+  const cid = 'bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupos'
+
+  // add the CID to the goodbits list
+  const goodbitsListKv = await mf.getKVNamespace('GOODBITSLIST')
+  await goodbitsListKv.put(
+    cid,
+    JSON.stringify({
+      tags: ['foo-bar-tag']
+    })
+  )
+
+  const response = await mf.dispatchFetch(`https://${cid}.ipfs.localhost:8787`)
+  await response.waitUntil()
+  t.is(await response.text(), 'Hello w3s.link! 😎')
+
+  // CSP exists
+  const csp = response.headers.get('content-security-policy')
+  t.truthy(csp)
 })

--- a/packages/edge-gateway-link/test/scripts/gateway.js
+++ b/packages/edge-gateway-link/test/scripts/gateway.js
@@ -1,17 +1,25 @@
+/* global Headers, Response */
+
 export default {
   /**
    * @param {Request} request
    */
-  async fetch(request) {
+  async fetch (request) {
     const reqUrl = new URL(request.url)
     // We need to perform requests as path based per localhost subdomain resolution
     const subdomainCid = getCidFromSubdomainUrl(reqUrl)
     if (subdomainCid) {
-      return new Response('Hello w3s.link! 😎')
+      const headers = new Headers({
+        etag: subdomainCid
+      })
+      return new Response('Hello w3s.link! 😎', {
+        headers,
+        status: 200
+      })
     }
 
     throw new Error('no cid in request')
-  },
+  }
 }
 
 /**
@@ -19,7 +27,7 @@ export default {
  *
  * @param {URL} url
  */
-function getCidFromSubdomainUrl(url) {
+function getCidFromSubdomainUrl (url) {
   const splitHost = url.hostname.split('.ipfs.')
 
   if (!splitHost.length) {

--- a/packages/edge-gateway-link/test/utils/miniflare.js
+++ b/packages/edge-gateway-link/test/utils/miniflare.js
@@ -24,11 +24,11 @@ export function getMiniflare () {
     mounts: {
       gateway: {
         scriptPath: './test/scripts/gateway.js',
-        modules: true,
-      },
+        modules: true
+      }
     },
     serviceBindings: {
-      EDGE_GATEWAY: 'gateway',
+      EDGE_GATEWAY: 'gateway'
     }
   })
 }

--- a/packages/edge-gateway-link/wrangler.toml
+++ b/packages/edge-gateway-link/wrangler.toml
@@ -27,6 +27,9 @@ routes = [
   { pattern = "*.ipns.w3s.link", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*/*", zone_id = "ae60d8f737317467ec666dc3851a6277" }
 ]
+kv_namespaces = [
+  { binding = "GOODBITSLIST", id = "292616354e2a4f83b7ac13ef30d66a30" }
+]
 
 [env.production.vars]
 GATEWAY_HOSTNAME = 'ipfs.w3s.link'
@@ -50,6 +53,9 @@ routes = [
   { pattern = "*.ipns-staging.w3s.link/*", zone_id = "ae60d8f737317467ec666dc3851a6277" },
   { pattern = "*.ipns-staging.w3s.link", zone_id = "ae60d8f737317467ec666dc3851a6277" }
 ]
+kv_namespaces = [
+  { binding = "GOODBITSLIST", id = "3905c48a814d4a938e500f8b890a8602" }
+]
 
 [env.staging.vars]
 GATEWAY_HOSTNAME = 'ipfs-staging.w3s.link'
@@ -65,6 +71,9 @@ environment = "production"
 # Test!
 [env.test]
 workers_dev = true
+kv_namespaces = [
+  { binding = "GOODBITSLIST" }
+]
 
 [env.test.vars]
 GATEWAY_HOSTNAME = 'ipfs.localhost:8787'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 importers:
 
@@ -28,6 +28,7 @@ importers:
       itty-router: ^2.4.5
       miniflare: ^2.5.0
       multiformats: ^9.6.4
+      p-retry: ^5.1.2
       sade: ^1.7.4
       smoke: ^3.1.1
       toml: ^3.0.0
@@ -36,6 +37,7 @@ importers:
     dependencies:
       itty-router: 2.6.1
       multiformats: 9.7.1
+      p-retry: 5.1.2
       toucan-js: 2.6.1
     devDependencies:
       '@cloudflare/workers-types': 3.14.1
@@ -401,9 +403,29 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
+  /@types/keyv/3.1.4:
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+    dependencies:
+      '@types/node': 18.11.9
+    dev: true
+
+  /@types/node/18.11.9:
+    resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
+    dev: true
+
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
+
+  /@types/responselike/1.0.0:
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+    dependencies:
+      '@types/node': 18.11.9
+    dev: true
+
+  /@types/retry/0.12.1:
+    resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
+    dev: false
 
   /@types/stack-trace/0.0.29:
     resolution: {integrity: sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g==}
@@ -460,6 +482,7 @@ packages:
 
   /@zxing/text-encoding/0.9.0:
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -835,6 +858,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /boxen/5.1.2:
@@ -870,6 +895,9 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       window: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /browser-process-hrtime/1.0.0:
@@ -1260,12 +1288,22 @@ packages:
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
     dev: true
@@ -1505,6 +1543,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1513,6 +1552,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1521,6 +1561,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1529,6 +1570,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1537,6 +1579,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1545,6 +1588,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1553,6 +1597,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1561,6 +1606,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1569,6 +1615,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1577,6 +1624,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1585,6 +1633,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1593,6 +1642,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1601,6 +1651,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1609,6 +1660,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1617,6 +1669,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1625,6 +1678,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1633,6 +1687,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1641,6 +1696,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1649,6 +1705,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1657,6 +1714,7 @@ packages:
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -1730,7 +1788,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-standard-jsx/11.0.0_1f83ac145f5a898154eb4284ebb8a6b5:
+  /eslint-config-standard-jsx/11.0.0_d6b2yfc7lkeycvhlikcoxofgwu:
     resolution: {integrity: sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==}
     peerDependencies:
       eslint: ^8.8.0
@@ -1740,7 +1798,7 @@ packages:
       eslint-plugin-react: 7.30.1_eslint@8.20.0
     dev: true
 
-  /eslint-config-standard/17.0.0_00020c76f0d787072cfef85ae1dd1d6f:
+  /eslint-config-standard/17.0.0_aabay5xq26dqolh67bnodxi5n4:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
       eslint: ^8.0.1
@@ -1759,14 +1817,33 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_ulu2225r2ychl26a37c6o2rfje:
     resolution: {integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /eslint-plugin-es/4.1.0_eslint@8.20.0:
@@ -1784,7 +1861,11 @@ packages:
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
@@ -1792,7 +1873,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.20.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_ulu2225r2ychl26a37c6o2rfje
       has: 1.0.3
       is-core-module: 2.9.0
       is-glob: 4.0.3
@@ -1800,6 +1881,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-n/15.2.4_eslint@8.20.0:
@@ -2010,6 +2095,8 @@ packages:
       debug: 3.2.7
       es6-promise: 4.2.8
       raw-body: 2.5.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /express/4.18.1:
@@ -2047,6 +2134,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /extend/3.0.2:
@@ -2123,6 +2212,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /find-up/2.1.0:
@@ -2206,6 +2297,7 @@ packages:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -2360,6 +2452,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.5
@@ -2884,6 +2978,9 @@ packages:
       whatwg-url: 7.1.0
       ws: 6.2.2
       xml-name-validator: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /json-buffer/3.0.0:
@@ -3273,6 +3370,8 @@ packages:
       depd: 2.0.0
       on-finished: 2.3.0
       on-headers: 1.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /mri/1.2.0:
@@ -3619,6 +3718,14 @@ packages:
     dependencies:
       aggregate-error: 3.1.0
     dev: true
+
+  /p-retry/5.1.2:
+    resolution: {integrity: sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      '@types/retry': 0.12.1
+      retry: 0.13.1
+    dev: false
 
   /p-timeout/3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
@@ -4100,6 +4207,11 @@ packages:
       signal-exit: 3.0.7
     dev: true
 
+  /retry/0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+    dev: false
+
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4219,6 +4331,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /serialize-error/7.0.1:
@@ -4236,6 +4350,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /set-blocking/2.0.0:
@@ -4332,6 +4448,8 @@ packages:
       morgan: 1.10.0
       multer: 1.4.4
       path-to-regexp: 6.2.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /source-map-support/0.5.21:
@@ -4444,14 +4562,17 @@ packages:
     hasBin: true
     dependencies:
       eslint: 8.20.0
-      eslint-config-standard: 17.0.0_00020c76f0d787072cfef85ae1dd1d6f
-      eslint-config-standard-jsx: 11.0.0_1f83ac145f5a898154eb4284ebb8a6b5
+      eslint-config-standard: 17.0.0_aabay5xq26dqolh67bnodxi5n4
+      eslint-config-standard-jsx: 11.0.0_d6b2yfc7lkeycvhlikcoxofgwu
       eslint-plugin-import: 2.26.0_eslint@8.20.0
       eslint-plugin-n: 15.2.4_eslint@8.20.0
       eslint-plugin-promise: 6.0.0_eslint@8.20.0
       eslint-plugin-react: 7.30.1_eslint@8.20.0
       standard-engine: 15.0.0
     transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
@@ -5009,6 +5130,9 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       jsdom: 13.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
 
   /word-wrap/1.2.3:
@@ -5065,6 +5189,14 @@ packages:
 
   /ws/6.2.2:
     resolution: {integrity: sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
     dependencies:
       async-limiter: 1.0.1
     dev: true


### PR DESCRIPTION
Applies csp headers with goodbits similarly to how nftstorage.link currently does. We have in nftstorage.link [hardcoded](https://github.com/nftstorage/nftstorage.link/blob/main/packages/edge-gateway/src/gateway.js#L60) `https://polygon-rpc.com https://rpc.testnet.fantom.network` for historical reasons on users of nftstorage.link. These were not included here.

TODO:
- [x] decide on goodbits location