### PR TITLE
fix: CSP directives

### DIFF
--- a/packages/edge-gateway-link/src/gateway.js
+++ b/packages/edge-gateway-link/src/gateway.js
@@ -66,7 +66,7 @@ function getTransformedResponseWithCspHeaders (response) {
 
   clonedResponse.headers.set(
     'content-security-policy',
-    "default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://*.w3s.link/* https://*.nftstorage.link/* https://*.dweb.link/* https://ipfs.io/ipfs/* https://*.githubusercontent.com; form-action 'self' ; navigate-to 'self'; connect-src 'self' blob: data: https://*.w3s.link/* https://*.nftstorage.link/* https://*.dweb.link/* https://ipfs.io/ipfs/*"
+    "default-src 'self' 'unsafe-inline' 'unsafe-eval' blob: data: https://*.w3s.link https://*.nftstorage.link https://*.dweb.link https://ipfs.io/ipfs/ https://*.githubusercontent.com; form-action 'self'; navigate-to 'self'; connect-src 'self' blob: data: https://*.w3s.link https://*.nftstorage.link https://*.dweb.link https://ipfs.io/ipfs/"
   )
 
   return clonedResponse

--- a/packages/edge-gateway-link/test/gateway.spec.js
+++ b/packages/edge-gateway-link/test/gateway.spec.js
@@ -20,7 +20,7 @@ test('Gets content from binding', async (t) => {
   const csp = response.headers.get('content-security-policy') || ''
   t.true(csp.includes("default-src 'self' 'unsafe-inline' 'unsafe-eval'"))
   t.true(csp.includes('blob: data'))
-  t.true(csp.includes("form-action 'self' ; navigate-to 'self';"))
+  t.true(csp.includes("form-action 'self'; navigate-to 'self';"))
 })
 
 test('Gets content with no csp header when goodbits csp bypass tag exists', async (t) => {


### PR DESCRIPTION
As per https://github.com/web3-storage/w3link/issues/27#issuecomment-1341743352 it looks like new headers did not worked.

I did some digging and I believe `*` in paths are taken literary not as a pattern to match. Unless I'm mistaken these change should fix the problem 