### PR TITLE
feat: add csp report endpoint

### DIFF
--- a/packages/edge-gateway-link/src/bindings.d.ts
+++ b/packages/edge-gateway-link/src/bindings.d.ts
@@ -11,6 +11,7 @@ export interface EnvInput {
   LOKI_TOKEN?: string
   EDGE_GATEWAY: Fetcher
   GATEWAY_HOSTNAME: string
+  CSP_REPORT_URI: string
   GOODBITSLIST: KVNamespace
 }
 

--- a/packages/edge-gateway-link/wrangler.toml
+++ b/packages/edge-gateway-link/wrangler.toml
@@ -33,6 +33,7 @@ kv_namespaces = [
 
 [env.production.vars]
 GATEWAY_HOSTNAME = 'ipfs.w3s.link'
+CSP_REPORT_URI = 'https://csp-report-to.web3.storage'
 DEBUG = "false"
 ENV = "production"
 
@@ -59,6 +60,7 @@ kv_namespaces = [
 
 [env.staging.vars]
 GATEWAY_HOSTNAME = 'ipfs-staging.w3s.link'
+CSP_REPORT_URI = 'https://staging.csp-report-to.web3.storage'
 DEBUG = "true"
 ENV = "staging"
 


### PR DESCRIPTION
Adds csp report endpoint. Be aware that for browser compatibility, we need to use new [report-to](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-to#browser_compatibility), as well as deprecated [report-uri](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri). This simply adds a secret with the URI, injects it into the headers and cleans up a bit the headers.

Closes https://github.com/web3-storage/w3link/issues/33