### PR TITLE
fix: handle redirect from edge gateway

### DIFF
--- a/packages/edge-gateway-link/src/gateway.js
+++ b/packages/edge-gateway-link/src/gateway.js
@@ -48,8 +48,13 @@ export async function gatewayGet (request, env) {
       ...request.cf || {},
       // @ts-ignore custom entry in cf object
       onlyIfCachedGateways: JSON.stringify(['https://nftstorage.link'])
-    }
+    },
+    redirect: 'manual'
   })
+
+  if (response.redirected) {
+    return response
+  }
 
   // Validation layer - CSP bypass
   const resourceCid = decodeURIComponent(

--- a/packages/edge-gateway-link/test/gateway.spec.js
+++ b/packages/edge-gateway-link/test/gateway.spec.js
@@ -23,6 +23,15 @@ test('Gets content from binding', async (t) => {
   t.true(csp.includes("form-action 'self'; navigate-to 'self';"))
 })
 
+test('redirects from binding', async (t) => {
+  const { mf } = t.context
+  const cid = 'bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4'
+
+  const response = await mf.dispatchFetch(`https://${cid}.ipfs.localhost:8787`)
+
+  t.is(response.status, 307)
+})
+
 test('Gets content with no csp header when goodbits csp bypass tag exists', async (t) => {
   const { mf } = t.context
   const cid = 'bafkreidyeivj7adnnac6ljvzj2e3rd5xdw3revw4da7mx2ckrstapoupor'

--- a/packages/edge-gateway-link/test/scripts/gateway.js
+++ b/packages/edge-gateway-link/test/scripts/gateway.js
@@ -1,5 +1,7 @@
 /* global Headers, Response */
 
+const IPFS_GATEWAY_REDIRECT_HOSTNAME = 'dweb.link'
+
 export default {
   /**
    * @param {Request} request
@@ -8,7 +10,14 @@ export default {
     const reqUrl = new URL(request.url)
     // We need to perform requests as path based per localhost subdomain resolution
     const subdomainCid = getCidFromSubdomainUrl(reqUrl)
-    if (subdomainCid) {
+
+    if (subdomainCid === 'bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4') {
+      return Response.redirect(
+        request.url.replace('localhost:8787', IPFS_GATEWAY_REDIRECT_HOSTNAME),
+        307
+      )
+    }
+    else if (subdomainCid) {
       const headers = new Headers({
         etag: subdomainCid
       })


### PR DESCRIPTION
Currently deployed to edge-gateway staging and seeing error with https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs-staging.nftstorage.link/ (error below).

This is because {w3link,nftstorage.link} interact with `edge-gateway`, which redirects over and over again because worker binding fetch follows redirect. [Making follow manual allows us to handle this and send back redirect response to users.](https://developers.cloudflare.com/workers/runtime-apis/request#requestinit)

I deployed this PR in w3link staging https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs-staging.w3s.link/ and is working

```
Too many redirects.https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs-staging.nftstorage.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/, https://bafybeiet3ym4yxqaqxbrhyvhaddi7wrglpkwoqjg5vwlsifv6duruw4vz4.ipfs.dweb.link/
```