### PR TITLE
Add polybase.xyz to `ALLOWED_LIST`

### DIFF
--- a/packages/edge-gateway-link/src/gateway.js
+++ b/packages/edge-gateway-link/src/gateway.js
@@ -16,7 +16,8 @@ const IPFS_GATEWAYS = [
 const ALLOWED_LIST = [
   'https://*.githubusercontent.com',
   'https://tableland.network',
-  'https://*.tableland.network'
+  'https://*.tableland.network',
+  'https://*.polybase.xyz'
 ]
 
 /**


### PR DESCRIPTION
Allow websites hosted on web3.storage to use [Polybase](https://polybase.xyz) - a global web3 database based on ZK proofs