### PR TITLE
Update gateway.js

### DIFF
--- a/packages/edge-gateway-link/src/gateway.js
+++ b/packages/edge-gateway-link/src/gateway.js
@@ -16,6 +16,7 @@ const IPFS_GATEWAYS = [
 ]
 const ALLOWED_LIST = [
   'https://*.githubusercontent.com',
+  'https://*.storacha.network',
   'https://tableland.network',
   'https://*.tableland.network'
 ]


### PR DESCRIPTION
When uploading files to Storacha via the @storacha/client library in an IPFS-deployed (browser-only) web app, the injected Content Security Policy from ipfs.w3s.link denied the HTTP request to the Storacha gateway with the following message in the browser:
```
"Refused to connect to 'https://up.storacha.network/' because it violates the following Content Security Policy directive: 

"connect-src 'self' blob: data: [https://%2.storacha.link/](https://%2.storacha.link/) [https://%2A.w3s.link/]
(https://%2A.w3s.link/) [https://%2A.nftstorage.link/](https://%2A.nftstorage.link/) [https://%2A.dweb.link/]
(https://%2A.dweb.link/) [https://ipfs.io/ipfs/](https://ipfs.io/ipfs/) [https://%2A.githubusercontent.com/]
(https://%2A.githubusercontent.com/) https://tableland.network/ https://%2A.tableland.network/"."
```
This PR adds *.storacha.network to the ALLOWED_LIST (since this isn’t an IPFS gateway in that sense) and should fix the issue.
